### PR TITLE
Asyncemit

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -66,6 +66,7 @@ function Compiler(directory, pipe, options) {
 }
 
 Compiler.prototype.__proto__ = require('eventemitter3').prototype;
+Compiler.prototype.asyncemit = require('asyncemit');
 
 /**
  * Create the BigPipe base front-end framework that's required for the handling
@@ -362,10 +363,10 @@ Compiler.prototype.catalog = function catalog(pages, done) {
    */
   function register(assemble, next) {
     async.each(Object.keys(assemble), function prefix(hash, fn) {
-      compiler.namespace(assemble[hash], function namespaced(error, file) {
-        if (error) return fn(error);
+      compiler.asyncemit('assembly', assemble[hash], function (err) {
+        if (err) return fn(err);
 
-        compiler.register(file);
+        compiler.register(assemble[hash]);
         fn();
       });
     }, next);

--- a/lib/file.js
+++ b/lib/file.js
@@ -73,7 +73,7 @@ File.readable('location', {
  * @api private
  */
 File.readable('set', function set(content) {
-  this.code = content;
+  this.code = content.toString('utf-8');
 
   //
   // Append async loading class to CSS

--- a/lib/file.js
+++ b/lib/file.js
@@ -69,17 +69,19 @@ File.readable('location', {
  * Update the content of the file, convert to Buffer if required and update length.
  *
  * @param {Buffer|String} content Content of the file.
- * @param {Boolean} append Add async CSS selector or not
  * @returns {File} fluent interface
  * @api private
  */
-File.readable('set', function set(content, append) {
-  if (this.is('css') && append) content = this.append(content, this.hash);
+File.readable('set', function set(content) {
+  this.code = content;
 
   //
-  // Append async loading class to CSS and make sure that the code is a Buffer.
+  // Append async loading class to CSS
   //
-  this.code = content;
+  if (this.is('css')) {
+    content = this.append(content, this.hash);
+  }
+
   this.buffer = Buffer.isBuffer(content) ? content : new Buffer(content);
   this.length = this.buffer.length;
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -44,7 +44,10 @@ function File(aliases, extname, dependency, code) {
   //
   // Process the content of the file if provided.
   //
-  if (code) this.set(code);
+  if (code) {
+    this.hash = this.encrypt(code);
+    this.set(code);
+  }
 }
 
 fuse(File, require('eventemitter3'));
@@ -71,7 +74,6 @@ File.readable('location', {
  * @api private
  */
 File.readable('set', function set(content, append) {
-  this.hash = this.encrypt(content);
   if (this.is('css') && append) content = this.append(content, this.hash);
 
   //

--- a/lib/file.js
+++ b/lib/file.js
@@ -111,7 +111,7 @@ File.readable('get', function get(readable) {
 File.readable('append', function append(content, hash) {
   return [
     content,
-    '#pagelet_',
+    '#_',
     hash || this.hash,
     ' { height: 42px }'
   ].join('');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "404-pagelet": "1.0.x",
     "500-pagelet": "1.0.x",
     "async": "0.9.x",
+    "asyncemit": "1.0.x",
     "bigpipe.js": "0.9.x",
     "bootstrap-pagelet": "1.0.x",
     "browserify": "9.0.x",

--- a/test/lib/file.test.js
+++ b/test/lib/file.test.js
@@ -118,11 +118,7 @@ describe('File', function () {
     });
 
     it('returns content with selector attached', function () {
-      assume(file.append(code)).to.equal(code + '#pagelet_' + sha + ' { height: 42px }');
-    });
-
-    it('can be provided with alternative hash', function () {
-      assume(file.append(code, 'test')).to.equal(code + '#pagelet_test { height: 42px }');
+      assume(file.append(code)).to.equal(code + '#_' + sha + ' { height: 42px }');
     });
   });
 

--- a/test/pipe.test.js
+++ b/test/pipe.test.js
@@ -226,7 +226,9 @@ describe('Pipe', function () {
 
     it('plugs in the provided plugins', function () {
       app.initialize(function optionStub(what, defaults) {
-        if (what === 'framework') return defaults;
+        if (what === 'framework') return Fittings.extend({
+          name: 'lol, stubbed'
+        });
 
         return [{
           name: 'test',


### PR DESCRIPTION
Asyncemit an assembly event instead of doing css namespacing by default which kinda belonged in `bigpipe.js` fitting instead of the core.

### todo

- [x] Append `#pagelet<hash>` to all css files.
- [x] Rename `#pagelet<hash>` to bigpipe?